### PR TITLE
custom ncRNA models for Infernal

### DIFF
--- a/loc_docker.config
+++ b/loc_docker.config
@@ -8,7 +8,6 @@ env {
 }
 
 params.GO_OBO = "/opt/go.obo"
-params.NCRNA_MODELS = "/opt/data/cm/rnas.cm"
 params.CIRCOS_CONFIG_FILE = "/opt/data/circos/circos.debian.conf"
 params.CIRCOS_BIN_CONFIG_FILE = "/opt/data/circos/circos.bin.debian.conf"
 params.ORTHOMCL_CONFIG_FILE = "/opt/data/orthomcl/orthomcl_sqlite.config"

--- a/loc_github.config
+++ b/loc_github.config
@@ -8,7 +8,6 @@ env {
 }
 
 params.GO_OBO = "/opt/go.obo"
-params.NCRNA_MODELS = "/opt/data/cm/rnas.cm"
 params.CIRCOS_CONFIG_FILE = "/opt/data/circos/circos.debian.conf"
 params.CIRCOS_BIN_CONFIG_FILE = "/opt/data/circos/circos.bin.debian.conf"
 params.ORTHOMCL_CONFIG_FILE = "/opt/data/orthomcl/orthomcl_sqlite.config"

--- a/loc_web.config
+++ b/loc_web.config
@@ -11,7 +11,6 @@ env {
 }
 
 params.GO_OBO = "${HOME}/go.obo"
-params.NCRNA_MODELS = "${baseDir}/data/cm/kinetoplastid_rnas.cm"
 params.CIRCOS_CONFIG_FILE = "${baseDir}/data/circos/circos.debian.conf"
 params.CIRCOS_BIN_CONFIG_FILE = "${baseDir}/data/circos/circos.bin.debian.conf"
 params.ORTHOMCL_CONFIG_FILE = "${baseDir}/data/orthomcl/orthomcl_sqlite.config"

--- a/params_default.config
+++ b/params_default.config
@@ -55,6 +55,9 @@ params {
     // for a less biased setting.
     WEIGHT_FILE = "${baseDir}/data/weight/weight_kinetoplastid.lua"
 
+    // covariance models for Infernal
+    NCRNA_MODELS = "${baseDir}/data/cm/rnas.cm"
+
     // Template for spec check output
     SPECK_TEMPLATE = "html"
 


### PR DESCRIPTION
Previously NCRNA_MODELS was set in loc_*.config, which meant that reference-dependent tuning of this parameter was not enabled (e.g. on loc_web.config, all runs were defaulting to kinetoplastid_rnas, even when that wasn't appropriate).

Placing the definition of this parameter in params_default.config instead allows reference-dependent tuning in the web interface by setting the value in companion.yml.